### PR TITLE
Pass config for adapter directly

### DIFF
--- a/Subscriber/AdapterCollectionSubscriber.php
+++ b/Subscriber/AdapterCollectionSubscriber.php
@@ -45,14 +45,6 @@ class AdapterCollectionSubscriber implements SubscriberInterface
 
         $config = array_merge($defaultConfig, $args->get('config'));
 
-        return new SftpAdapter([
-            'host' => $config['host'],
-            'port' => $config['port'],
-            'username' => $config['username'],
-            'password' => $config['password'],
-            'privateKey' => $config['privateKey'],
-            'root' => $config['root'],
-            'timeout' => $config['timeout']
-        ]);
+        return new SftpAdapter($config);
     }
 }


### PR DESCRIPTION
In order to make it possible to set all config values we can pass the config array directly instead of mapping all individual fields.
The SftpAdapter holds an array of all configurable fields and only if the field is listed it will be set.
> protected $configurable = ['host', 'hostFingerprint', 'port', 'username', 'password', 'useAgent', 'agent', 'timeout', 'root', 'privateKey', 'permPrivate', 'permPublic', 'directoryPerm', 'NetSftpConnection'];

I need to set "directoryPerm" in my case and currently this is not possible.